### PR TITLE
Don't need an explicit kwarg when using **kwargs

### DIFF
--- a/data.py
+++ b/data.py
@@ -9,10 +9,10 @@ from discord.ext.commands import AutoShardedBot as _Bot
 
 
 class Bot(_Bot):
-    def __init__(self, *args, prefix=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         with open("config.json") as f:
             self.config = json.load(f)
-        self.prefix = prefix
+        self.prefix = kwargs.get("prefix")
         self.executor = ThreadPoolExecutor(max_workers=16)
         super().__init__(*args, **kwargs)
 

--- a/data.py
+++ b/data.py
@@ -5,10 +5,10 @@ try:
     import ujson as json
 except ImportError:
     import json
-from discord.ext.commands import AutoShardedBot as _Bot
+from discord.ext.commands import AutoShardedBot
 
 
-class Bot(_Bot):
+class Bot(AutoShardedBot):
     def __init__(self, *args, **kwargs):
         with open("config.json") as f:
             self.config = json.load(f)


### PR DESCRIPTION
Cleans up the method signature